### PR TITLE
adds support for single pkg lookup with a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var pkgs = module.exports = function(names, options, callback) {
   }
 
   if (typeof names === 'string') {
-    names = [names];
+    names = names.split(' ');
   }
 
   async.map(

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,17 @@ describe("pkgs", function() {
     })
   })
 
+  it("fetches multiple packages' metadata if packages are entered as a string separated by spaces", function (done) {
+    pkgs("lodash domready", function (err, res) {
+      assert(!err)
+      assert(Array.isArray(res))
+      assert.equal(res.length, 2)
+      assert.equal(res[0].name, "lodash")
+      assert.equal(res[1].name, "domready")
+      done()
+    })
+  })
+
   it("picks all properties by default", function(done) {
     pkgs(["superagent"], function(err, res) {
       assert(!err)


### PR DESCRIPTION
this module is great! I noticed that if I tried to look up only one package, i.e. `pkgs('lodash', ...)`, it would look up packages `l`, `o`, `d`, etc. So I took a stab at fixing it :-)

What do you think?
