### PR TITLE
allow the npm-stats subdependency to be configured with a new registry

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 var _ = require("lodash")
 var async = require("async")
-var registry = require("npm-stats")()
+var npmStats = require("npm-stats")
 var pkgs = module.exports = function(names, options, callback) {
-
   if (arguments.length === 3) {
     // Allow shorthand syntax, where options is actually
     // an array of desired property names
@@ -15,6 +14,8 @@ var pkgs = module.exports = function(names, options, callback) {
     callback = options
     options = {}
   }
+
+  var registry = npmStats(undefined, options.npmStats)
 
   if (typeof names === 'string') {
     names = names.split(' ');

--- a/test/index.js
+++ b/test/index.js
@@ -107,4 +107,16 @@ describe("pkgs", function() {
     })
   })
 
+  it("allows configuration to be passed to the npm-stats sub-dependency", function (done) {
+    pkgs("lodash", {npmStats: {
+      registry: 'https://registry.npmjs.org',
+      modules: ''
+    }}, function (err, res) {
+      assert(!err)
+      assert(Array.isArray(res))
+      assert.equal(res.length, 1)
+      assert.equal(res[0].name, "lodash")
+      done()
+    })
+  })
 })


### PR DESCRIPTION
I'm using this module with npm On-Site, it would be awesome to be able to pass in a new registry to the npm-stats sub-dependency.
